### PR TITLE
Add detailed data & graphs for each site

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "collect-stats": "node scripts/collect-stats"
   },
   "devDependencies": {
+    "@types/byte-size": "^8.1.0",
     "astro": "^1.0.0-beta.20",
+    "byte-size": "^8.1.0",
     "fast-glob": "^3.2.11",
     "performance-leaderboard": "^9.2.0",
     "short-hash": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,14 +1,18 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/byte-size': ^8.1.0
   astro: ^1.0.0-beta.20
+  byte-size: ^8.1.0
   fast-glob: ^3.2.11
   performance-leaderboard: ^9.2.0
   short-hash: ^1.0.0
   speedlify-score: ^2.0.2
 
 devDependencies:
+  '@types/byte-size': 8.1.0
   astro: 1.0.0-beta.40
+  byte-size: 8.1.0
   fast-glob: 3.2.11
   performance-leaderboard: 9.6.1
   short-hash: 1.0.0
@@ -472,6 +476,10 @@ packages:
       '@types/estree': 0.0.51
     dev: true
 
+  /@types/byte-size/8.1.0:
+    resolution: {integrity: sha512-LCIlZh8vyx+I2fgRycE1D34c33QDppYY6quBYYoaOpQ1nGhJ/avSP2VlrAefVotjJxgSk6WkKo0rTcCJwGG7vA==}
+    dev: true
+
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -810,6 +818,11 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
+
+  /byte-size/8.1.0:
+    resolution: {integrity: sha512-FkgMTAg44I0JtEaUAvuZTtU2a2YDmBRbQxdsQNSMtLCjhG0hMcF5b1IMN9UjSCJaU4nvlj/GER7B9sI4nKdCgA==}
+    engines: {node: '>=12.17'}
     dev: true
 
   /call-bind/1.0.2:

--- a/public/style.css
+++ b/public/style.css
@@ -1,9 +1,6 @@
-* {
-  box-sizing: border-box;
-}
 html,
 body {
-  height: 100%;
+  min-height: 100%;
 }
 html {
   color: #fffc;
@@ -22,10 +19,29 @@ body {
 }
 h1 {
   font-size: 3em;
+  line-height: 1;
 }
 a {
   color: white;
 }
 footer {
   margin: 1rem;
+}
+code {
+  font-family: Monaco, monospace;
+}
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
+html:not(.js) [data-js-only] {
+  display: none !important;
 }

--- a/src/components/FileSize.astro
+++ b/src/components/FileSize.astro
@@ -1,0 +1,35 @@
+---
+import byteSize from 'byte-size';
+
+export interface Props {
+  size: number;
+}
+
+const { size } = Astro.props as Props;
+const { unit, value } = byteSize(size, { units: 'iec', precision: 0 });
+---
+
+<span class="filesize">
+  {value}<span class="filesize-label-sm">{unit.slice(0, 1)}</span><span class="filesize-label-lg"> {unit}</span>
+</span>
+
+<style>
+  .filesize-label-lg {
+    display: none;
+  }
+
+  @media (min-width: 31.25em) {
+    .filesize-label-sm {
+      display: none;
+    }
+
+    .filesize-label-lg {
+      display: inline;
+    }
+  }
+
+  :global([data-numeric-value="0"]) .filesize-label-sm,
+  :global([data-numeric-value="0"]) .filesize-label-lg {
+    display: none;
+  }
+</style>

--- a/src/components/LighthouseResults.astro
+++ b/src/components/LighthouseResults.astro
@@ -1,0 +1,117 @@
+---
+import type { TestData } from "../util/data";
+import { displayDate } from "../util/formatters";
+
+export interface Props {
+  entries: TestData[];
+}
+
+const { entries } = Astro.props as Props;
+---
+
+<div class="layout color--lighthouse">
+  <div class="tablewrap">
+    <table data-make-chart class="results">
+      <thead>
+        <tr>
+          <th rowspan={2} class="results-date">Date</th>
+          <th rowspan={2} colspan={2}>Rank</th>
+          <th colspan={9}>Lighthouse</th>
+          <th colspan={2} rowspan={2}>Axe</th>
+        </tr>
+        <tr>
+          <th class="results-series-a" colspan={3}><abbr title="Performance">Perf</abbr></th>
+          <th class="results-series-b" colspan={2}><abbr title="Accessibility">A11Y</abbr></th>
+          <th class="results-series-c" colspan={2}>Best Practices</th>
+          <th class="results-series-d" colspan={2}>SEO</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((entry) => (
+        <tr>
+          <td><code class="date">{displayDate(entry.timestamp)}</code></td>
+          <td class="results-bool">
+            {entry.ranks.cumulative ? (
+            [,'🥇','🥈','🥉'][entry.ranks.cumulative]
+            ) : entry.ranks.hundos && (
+            [,'🥇','🥈','🥉'][entry.ranks.hundos]
+            )}
+          </td>
+          <td>{entry.ranks.cumulative ? `#${entry.ranks.cumulative}` : entry.ranks.hundos && `#${
+            entry.ranks.hundos }`}</td>
+          <td class="results-bool">
+            {
+            entry.lighthouse.performance === 1
+            ? <span class="leaderboard-hide-sm">✅</span>
+            : entry.lighthouse.performance >= 0.9
+            ? ''
+            : entry.lighthouse.performance >= 0.5
+            ? <span class="leaderboard-hide-sm">⚠️</span>
+            : '🚫'
+            }
+          </td>
+          <td data-numeric-value={Math.round(entry.lighthouse.performance * 100)}>
+            {Math.round(entry.lighthouse.performance * 100)}</td>
+          <td class="results-calc">
+            <a href={`https://googlechrome.github.io/lighthouse/scorecalc/#FCP=${ entry.firstContentfulPaint }&SI=${
+              entry.speedIndex }&LCP=${ entry.largestContentfulPaint }&TTI=${ entry.timeToInteractive }&TBT=${
+              entry.totalBlockingTime }&CLS=${ entry.cumulativeLayoutShift }&FCI=&FMP=&device=${ entry.lighthouse.type
+              || "mobile" }&version=${ entry.lighthouse.version || "6.0.0" }`} target="_blank" rel="noopener noreferrer"
+              class="leaderboard-hide-md">
+              Calculator
+            </a>
+          </td>
+          <td class="results-bool">{
+            entry.lighthouse.accessibility === 1
+            ? <span class="leaderboard-hide-sm">✅</span>
+            : entry.lighthouse.accessibility >= 0.9
+            ? ''
+            : entry.lighthouse.accessibility >= 0.5
+            ? <span class="leaderboard-hide-sm">⚠️</span>
+            : '🚫'
+            }</td>
+          <td data-numeric-value={Math.round(entry.lighthouse.accessibility * 100)}>
+            {Math.round(entry.lighthouse.accessibility * 100)}</td>
+          <td class="results-bool">{
+            entry.lighthouse.bestPractices === 1
+            ? <span class="leaderboard-hide-sm">✅</span>
+            : entry.lighthouse.bestPractices >= 0.9
+            ? ''
+            : entry.lighthouse.bestPractices >= 0.5
+            ? <span class="leaderboard-hide-sm">⚠️</span>
+            : '🚫'
+            }</td>
+          <td data-numeric-value={Math.round(entry.lighthouse.bestPractices * 100)}>
+            {Math.round(entry.lighthouse.bestPractices * 100)}</td>
+          <td class="results-bool">{
+            entry.lighthouse.seo === 1
+            ? <span class="leaderboard-hide-sm">✅</span>
+            : entry.lighthouse.seo >= 0.9
+            ? ''
+            : entry.lighthouse.seo >= 0.5
+            ? <span class="leaderboard-hide-sm">⚠️</span>
+            : '🚫'
+            }</td>
+          <td data-numeric-value={Math.round(entry.lighthouse.seo * 100)}>{Math.round(entry.lighthouse.seo * 100)}
+          </td>
+          <td class="results-bool">{entry.axe.violations == 0 ? <span class="leaderboard-hide-sm">✅</span> : '🚫'}
+          </td>
+          <td>{entry.axe.error ? 'Error' : entry.axe.violations }</td>
+        </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+  <div data-js-only class="ct-chart ct-double-octave"></div>
+</div>
+
+<style>
+  .color--lighthouse {
+    --speedlify-color-1: #004e5f;
+    --speedlify-color-2: #006a6c;
+    --speedlify-color-3: #00845f;
+    --speedlify-color-4: #4f9a3e;
+    --speedlify-color-5: #a3a704;
+    --speedlify-color-6: #ffa600;
+  }
+</style>

--- a/src/components/SiteDetails.astro
+++ b/src/components/SiteDetails.astro
@@ -1,0 +1,280 @@
+---
+import type { TestData } from "../util/data";
+import LighthouseResults from "./LighthouseResults.astro";
+import WeightResults from "./WeightResults.astro";
+import WebVitalsResults from "./WebVitalsResults.astro";
+
+export interface Props {
+  site: { [date: string]: TestData };
+  urlHash: string;
+}
+
+const { site, urlHash } = Astro.props as Props;
+const entries = Object.values(site)
+  .sort((a, b) => b.timestamp - a.timestamp)
+  .slice(0, 10);
+---
+
+<tr class="leaderboard-list-entry-details">
+  <td colspan={6}>
+    <details class="leaderboard-details" id={`details-${urlHash}`}>
+      <summary>Show Data</summary>
+      <LighthouseResults {...{entries}} />
+      <WebVitalsResults {...{entries}} />
+      <WeightResults {...{entries}} />
+    </details>
+  </td>
+</tr>
+
+<script>
+  import './SiteDetails.ts';
+</script>
+
+<style is:global>
+  @import 'https://esm.sh/chartist@0.11.4/dist/chartist.min.css';
+
+  /* Charts */
+  .ct-chart.ct-chart {
+    margin-bottom: 2em;
+  }
+
+  .ct-line.ct-line {
+    stroke-width: 3px;
+  }
+
+  .ct-label.ct-label {
+    fill: rgba(255, 255, 255, 0.4);
+    color: rgba(255, 255, 255, 0.4);
+    white-space: nowrap;
+  }
+
+  .ct-grid.ct-grid {
+    stroke: rgba(255, 255, 255, 0.2);
+  }
+
+  a[href^="#details-"] {
+    white-space: nowrap;
+    display: inline-block;
+    text-decoration: none;
+    background-color: #fff2;
+    border-radius: 50px;
+    border: 1px solid #aaa;
+    padding: .5em 1em;
+    text-align: center;
+    line-height: normal;
+  }
+
+  .leaderboard-list-entry.expanded [data-expand-alias] {
+    border-color: transparent;
+  }
+
+  .js .leaderboard-list-entry-details:not(.expanded) {
+    display: none;
+  }
+
+  .js .leaderboard-details > summary {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  .expanded {
+    background-color: #000;
+  }
+
+  .leaderboard-list-entry.expanded {
+    border-color: #fff;
+  }
+
+  .leaderboard-list-entry.expanded .leaderboard-expand-icon {
+    transform: rotate(90deg);
+  }
+
+  .leaderboard-expand-icon {
+    display: inline-block;
+    transition: .3s all;
+    transform-origin: center;
+    margin-right: 4px;
+  }
+
+  .leaderboard-expand-icon::before {
+    content: "";
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    border-left: 7px solid #aaa;
+  }
+
+  .results-series-a {
+    background-color: var(--speedlify-color-1);
+  }
+
+  .ct-series-a.ct-series-a .ct-line {
+    stroke: var(--speedlify-color-1);
+  }
+
+  .results-series-b {
+    background-color: var(--speedlify-color-2);
+  }
+
+  .ct-series-b.ct-series-b .ct-line {
+    stroke: var(--speedlify-color-2);
+  }
+
+  .results-series-c {
+    background-color: var(--speedlify-color-3);
+  }
+
+  .ct-series-c.ct-series-c .ct-line {
+    stroke: var(--speedlify-color-3);
+  }
+
+  .results-series-d {
+    background-color: var(--speedlify-color-4);
+  }
+
+  .ct-series-d.ct-series-d .ct-line {
+    stroke: var(--speedlify-color-4);
+  }
+
+  .results-series-e {
+    background-color: var(--speedlify-color-5);
+  }
+
+  .ct-series-e.ct-series-e .ct-line {
+    stroke: var(--speedlify-color-5);
+  }
+
+  .results-series-f {
+    background-color: var(--speedlify-color-6);
+  }
+
+  .ct-series-f.ct-series-f .ct-line {
+    stroke: var(--speedlify-color-6);
+  }
+
+  .tablewrap {
+    width: 100%;
+    margin: 0 0 2em;
+  }
+
+  @media (min-width: 87.5em) {
+    .layout {
+      display: grid;
+      grid-gap: 1em;
+      margin-bottom: 2em;
+    }
+
+    .js .layout {
+      grid-template-columns: repeat(auto-fill, 49%);
+    }
+  }
+
+  [data-numeric-value="0"] .count {
+    display: none;
+  }
+
+  /* Results table */
+  .results {
+    width: 100%;
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+
+  .results th,
+  .results td {
+    padding: .25em;
+    font-weight: normal;
+  }
+
+  @media (min-width: 25em) {
+
+    .results th,
+    .results td {
+      padding-left: .5em;
+      padding-right: .5em;
+    }
+  }
+
+  .results th {
+    color: #fff;
+    border: 1px dotted rgba(255, 255, 255, 0.3);
+    text-align: center;
+  }
+
+  .results th:first-child {
+    border-left: none;
+  }
+
+  @media (max-width: 87.4375em) {
+
+    .results th:last-child {
+      border-right: none;
+    }
+  }
+
+  .results tr:first-child th {
+    font-weight: bold;
+  }
+
+  .results td {
+    white-space: nowrap;
+  }
+
+  .results-calc {
+    text-align: center;
+  }
+
+  .results-bool {
+    width: 1ch;
+  }
+
+  .results-bool+td {
+    padding-left: 0;
+  }
+
+  .results-date {
+    width: 6.25rem;
+  }
+
+  .leaderboard .results th,
+  .leaderboard .results td {
+    font-size: 0.6875rem;
+  }
+
+  @media (min-width: 31.25em) {
+
+    .leaderboard .results th,
+    .leaderboard .results td {
+      font-size: 0.875rem;
+    }
+  }
+
+  @media (min-width: 50em) {
+
+    .leaderboard .results th,
+    .leaderboard .results td {
+      font-size: .9375rem;
+    }
+  }
+
+  @media (max-width: 37.4375em) {
+    .leaderboard-hide-sm {
+      display: none;
+    }
+  }
+
+  @media (max-width: 64em) {
+    .leaderboard-hide-md {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/SiteDetails.ts
+++ b/src/components/SiteDetails.ts
@@ -1,0 +1,95 @@
+import Chartist from 'https://esm.sh/chartist@0.11.4';
+
+function makeTable(table: Element) {
+  const labels = [];
+  const series = [];
+
+  let rows = Array.from(table.querySelectorAll(':scope tbody tr'));
+  let minY = 90;
+  let maxY = 100;
+  rows = rows.reverse();
+
+  for (let row of rows) {
+    const label = row.children[0].innerText.split(' ');
+    labels.push(label.slice(0, 2).join(' '));
+    const childCount = row.children.length - 1;
+    let seriesIndex = 0;
+    for (let j = 0, k = childCount; j < k; j++) {
+      const data = row.children[j + 1].dataset;
+      if (data && data.numericValue) {
+        minY = Math.min(data.numericValue, minY);
+        maxY = Math.max(data.numericValue, maxY);
+        if (!series[seriesIndex]) {
+          series[seriesIndex] = [];
+        }
+        series[seriesIndex].push(data.numericValue);
+        seriesIndex++;
+      }
+    }
+  }
+
+  const options = {
+    high: Math.max(maxY, 100),
+    low: Math.max(0, minY - 5),
+    fullWidth: true,
+    onlyInteger: true,
+    showPoint: false,
+    lineSmooth: true,
+    axisX: {
+      showGrid: true,
+      showLabel: true,
+    },
+    chartPadding: {
+      right: 40,
+    },
+  };
+
+  new Chartist.Line(
+    table.parentNode.nextElementSibling,
+    {
+      labels: labels,
+      series: series,
+    },
+    options
+  );
+}
+
+function initializeAllTables(scope: Document | Element) {
+  const tables = scope.querySelectorAll('[data-make-chart]');
+  for (let table of tables) {
+    // make sure not in a closed details
+    if (table.closest('details[open]') || !table.closest('details')) {
+      makeTable(table);
+    }
+  }
+}
+
+initializeAllTables(document);
+
+const details = document.querySelectorAll('details');
+for (const detail of details) {
+  detail.addEventListener('toggle', function (e) {
+    const open = e.target.hasAttribute('open');
+    if (open) initializeAllTables(e.target);
+
+    const row = e.target.closest('.leaderboard-list-entry-details');
+    row.classList.toggle('expanded', open);
+    row.previousElementSibling.classList.toggle('expanded', open);
+  });
+}
+
+const expandAliases = document.querySelectorAll('[data-expand-alias]');
+for (const alias of expandAliases) {
+  alias.addEventListener(
+    'click',
+    function (e) {
+      e.preventDefault();
+      const href = e.target.closest('a[href]').getAttribute('href');
+      if (href) {
+        const details = document.querySelector(href);
+        if (details) details.open = !details.hasAttribute('open');
+      }
+    },
+    false
+  );
+}

--- a/src/components/WebVitalsResults.astro
+++ b/src/components/WebVitalsResults.astro
@@ -1,0 +1,101 @@
+---
+import type { TestData } from "../util/data";
+import { displayDate, displayTime, showDigits } from "../util/formatters";
+
+export interface Props {
+  entries: TestData[];
+}
+
+const { entries } = Astro.props as Props;
+
+const lighthouseMaximums = {
+  average: { fcp: 4000, si: 5800, lcp: 4000, tti: 7300, tbt: 600, cls: 0.25 },
+  good: { fcp: 2336, si: 3387, lcp: 2500, tti: 3875, tbt: 287, cls: 0.1 },
+};
+---
+
+<div class="layout color--vitals">
+  <div class="tablewrap">
+    <table data-make-chart class="results">
+      <thead>
+        <tr>
+          <th rowspan={2} class="results-date">Date</th>
+          <th colspan={8}>Core Web Vitals</th>
+          <th colspan={6}>Web Vitals</th>
+        </tr>
+        <tr>
+          <th class="results-series-a" colspan={2}><abbr title="Largest Contentful Paint">LCP</abbr></th>
+          <th class="results-series-b" colspan={2}>Max <span class="leaderboard-hide-sm">Potential </span><abbr
+              title="First Input Delay">FID</abbr></th>
+          <th class="results-series-c" colspan={2}><abbr title="Total Blocking Time">TBT</abbr></th>
+          <th colspan={2}><abbr title="Cumulative Layout Shift">CLS</abbr></th>
+          <th class="results-series-d" colspan={2}><abbr title="First Contentful Paint">FCP</abbr></th>
+          <th class="results-series-e" colspan={2}><abbr title="Speed Index">SI</abbr></th>
+          <th class="results-series-f" colspan={2}><abbr title="Time to Interactive">TTI</abbr></th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(entry => <tr>
+          <td><code class="date">{displayDate(entry.timestamp)}</code></td>
+          <td class="results-bool">{
+            entry.largestContentfulPaint > lighthouseMaximums.average.lcp
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.largestContentfulPaint > lighthouseMaximums.good.lcp
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td data-numeric-value={entry.largestContentfulPaint}>{displayTime(entry.largestContentfulPaint)}</td>
+          <td class="results-bool"></td>
+          <td data-numeric-value={entry.maxPotentialFirstInputDelay}>
+            {displayTime(entry.maxPotentialFirstInputDelay)}</td>
+          <td class="results-bool">{
+            entry.totalBlockingTime > lighthouseMaximums.average.tbt
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.totalBlockingTime > lighthouseMaximums.good.tbt
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td data-numeric-value={entry.totalBlockingTime}>{displayTime(entry.totalBlockingTime)}</td>
+          <td class="results-bool">{
+            entry.cumulativeLayoutShift > lighthouseMaximums.average.cls
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.cumulativeLayoutShift > lighthouseMaximums.good.cls
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td>{showDigits(entry.cumulativeLayoutShift, 2)}</td>
+          <td class="results-bool">{
+            entry.firstContentfulPaint > lighthouseMaximums.average.fcp
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.firstContentfulPaint > lighthouseMaximums.good.fcp
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td data-numeric-value={entry.firstContentfulPaint}>{displayTime(entry.firstContentfulPaint)}</td>
+          <td class="results-bool">{
+            entry.speedIndex > lighthouseMaximums.average.si
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.speedIndex > lighthouseMaximums.good.si
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td data-numeric-value={entry.speedIndex}>{displayTime(entry.speedIndex)}</td>
+          <td class="results-bool">{
+            entry.timeToInteractive > lighthouseMaximums.average.tti
+            ? <span class="leaderboard-hide-sm">🚫</span>
+            : entry.timeToInteractive > lighthouseMaximums.good.tti
+            && <span class="leaderboard-hide-sm">⚠️</span>
+            }</td>
+          <td data-numeric-value={entry.timeToInteractive}>{displayTime(entry.timeToInteractive)}</td>
+        </tr>)}
+      </tbody>
+    </table>
+  </div>
+  <div data-js-only class="ct-chart ct-double-octave"></div>
+</div>
+
+<style>
+  .color--vitals {
+    --speedlify-color-1: #374c80;
+    --speedlify-color-2: #7a5195;
+    --speedlify-color-3: #bc5090;
+    --speedlify-color-4: #ef5675;
+    --speedlify-color-5: #ff764a;
+    --speedlify-color-6: #ffa600;
+  }
+</style>

--- a/src/components/WeightCell.astro
+++ b/src/components/WeightCell.astro
@@ -1,0 +1,18 @@
+---
+import FileSize from "./FileSize.astro";
+
+export interface Props {
+  size: number;
+  count?: number;
+}
+
+const { size, count } = Astro.props as Props;
+---
+
+<td data-numeric-value={size / 1024}>
+  {size || size === 0
+  ? <>
+    <FileSize size={size} /> {count !== undefined && <span class="count leaderboard-hide-sm">×{count}</span>}
+  </>
+  : '❓'}
+</td>

--- a/src/components/WeightResults.astro
+++ b/src/components/WeightResults.astro
@@ -1,0 +1,57 @@
+---
+import type { TestData } from "../util/data";
+import { displayDate } from "../util/formatters";
+import WeightCell from "./WeightCell.astro";
+
+export interface Props {
+  entries: TestData[];
+}
+
+const { entries } = Astro.props as Props;
+---
+
+<div class="layout color--weight">
+  <div class="tablewrap">
+    <table data-make-chart class="results">
+      <thead>
+        <tr>
+          <th rowspan={2} class="results-date">Date</th>
+          <th colspan={7}>Weight</th>
+        </tr>
+        <tr>
+          <th class="results-series-a">Total</th>
+          <th class="results-series-b">HTML</th>
+          <th class="results-series-c"><abbr title="Cascading Style Sheets">CSS</abbr></th>
+          <th class="results-series-d"><abbr title="JavaScript">JS</abbr></th>
+          <th class="results-series-e">Images</th>
+          <th class="results-series-f">Fonts</th>
+          <th>Third Party</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(entry => <tr>
+          <td><code class="date">{displayDate(entry.timestamp)}</code></td>
+          <WeightCell size={entry.weight.total} />
+          <WeightCell size={entry.weight.document} />
+          <WeightCell size={entry.weight.stylesheet} count={entry.weight.stylesheet} />
+          <WeightCell size={entry.weight.script} count={entry.weight.scriptCount} />
+          <WeightCell size={entry.weight.image} count={entry.weight.imageCount} />
+          <WeightCell size={entry.weight.font} count={entry.weight.fontCount} />
+          <WeightCell size={entry.weight.thirdParty} count={entry.weight.thirdPartyCount} />
+        </tr>)}
+      </tbody>
+    </table>
+  </div>
+  <div data-js-only class="ct-chart ct-double-octave"></div>
+</div>
+
+<style>
+  .color--weight {
+    --speedlify-color-1: #5100ff;
+    --speedlify-color-2: #de00c3;
+    --speedlify-color-3: #ff0085;
+    --speedlify-color-4: #ff004f;
+    --speedlify-color-5: #ff6c22;
+    --speedlify-color-6: #ffa600;
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,6 +35,8 @@ const ogImageAlt = `Screenshot of “${title}”`;
 		<meta name="twitter:description" content={description}>
 		<meta name="twitter:image" content={ogImageSrc}>
 		<meta name="twitter:image:alt" content={ogImageAlt} />
+
+		<script is:inline>document.documentElement.classList.add("js");</script>
 	</head>
 	<body>
 		<h1>Hyperdrive Speedometer</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import shorthash from 'short-hash';
 import 'speedlify-score/speedlify-score.css';
+import SiteDetails from '../components/SiteDetails.astro';
 import Layout from '../layouts/Layout.astro';
 import { loadResults } from '../util/data';
 
@@ -19,7 +20,8 @@ const results = await loadResults();
 			<th>Rank</th>
 			<th class="leaderboard-hide-md">Trophy</th>
 			<th>URL</th>
-			<th>Lighthouse</th>
+			<th class="leaderboard-score">Lighthouse</th>
+			<th class="leaderboard-data-right"><span class="sr-only">Data and Graphs</span></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -27,7 +29,8 @@ const results = await loadResults();
 		const newestKey = getNewestKey(site);
 		const latest = site[newestKey];
 		if (latest.error) return null;
-		const id = 'site-' + shorthash(latest.url);
+		const urlHash = shorthash(latest.url);
+		const id = 'site-' + urlHash;
 		const displayURL = url => url.replace(/^https?:\/\//, '');
 		const hasRedirect = latest.requestedUrl && latest.requestedUrl !== latest.url
 		const isNew = Object.keys(site).length === 1;
@@ -51,8 +54,12 @@ const results = await loadResults();
 						raw-data={JSON.stringify(latest)}
 					></speedlify-score>
 					<span class="leaderboard-score-sum leaderboard-number">{latest.lighthouse.total === 400 ? '😍' : latest.lighthouse.total }</span>
+					<td class="leaderboard-data-right"><a href={`#details-${urlHash}`} data-expand-alias data-js-only>
+						<span class="leaderboard-expand-icon"></span> Data<span class="leaderboard-hide-md"> and Graphs</span></a>
+					</td>
 				</td>
 			</tr>
+			<SiteDetails {...{site, urlHash}} />
 		);
 	})}
 	</tbody>
@@ -69,7 +76,7 @@ const results = await loadResults();
 .leaderboard {
 	margin: 5em auto;
 	width: 100%;
-	max-width: 70rem;
+	max-width: 90rem;
 	border-spacing: 0;
 	border-collapse: collapse;
 	text-align: left;
@@ -81,12 +88,18 @@ const results = await loadResults();
 	font-weight: normal;
 }
 
-.leaderboard td {
-	font-size: 1.3125em;
+@media (min-width: 50em) {
+	.leaderboard td {
+		font-size: 1.3125em;
+	}
 }
 
 .leaderboard :is(th,td) {
 	padding: .75rem .5rem;
+}
+
+.leaderboard-data-right {
+	text-align: right;
 }
 
 .leaderboard-list-entry {
@@ -111,8 +124,13 @@ const results = await loadResults();
 }
 
 .url {
-	font-size: 1.25em;
 	word-break: break-word;
+}
+
+@media (min-width: 37.5em) {
+	.url {
+		font-size: 1.25em;
+	}
 }
 
 .leaderboard-redirect-error,
@@ -161,6 +179,12 @@ a[href^="#"] {
 .leaderboard-score-sum {
 	display: inline-block;
 	vertical-align: middle;
+}
+
+@media (max-width: 29em) {
+	.leaderboard-score {
+		display: none;
+	}
 }
 
 @media (max-width: 64em) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ const getNewestKey = (obj: Record<string, { timestamp: number }>) => {
 const results = await loadResults();
 ---
 <Layout>
+<div class="leaderboard-wrapper">
 <table class="leaderboard">
 	<thead>
 		<tr>
@@ -55,10 +56,15 @@ const results = await loadResults();
 	})}
 	</tbody>
 </table>
+</div>
 <script>import 'speedlify-score';</script>
 </Layout>
 
 <style>
+.leaderboard-wrapper {
+	margin-left: -.5rem;
+	margin-right: -.4375rem;
+}
 .leaderboard {
 	margin: 5em auto;
 	width: 100%;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,13 +30,14 @@ const results = await loadResults();
 		const id = 'site-' + shorthash(latest.url);
 		const displayURL = url => url.replace(/^https?:\/\//, '');
 		const hasRedirect = latest.requestedUrl && latest.requestedUrl !== latest.url
+		const isNew = Object.keys(site).length === 1;
 		
 		return (
 			<tr {id} class="leaderboard-list-entry">
 				<td>
 					<a href={`#${id}`}>{index + 1}</a>
 				</td>
-				<td class="leaderboard-hide-md leaderboard-trophies">{latest.lighthouse.total === 400 && '🏆'}{['🥇','🥈','🥉'][index]}</td>
+				<td class="leaderboard-hide-md leaderboard-trophies">{latest.lighthouse.total === 400 && '🏆'}{['🥇','🥈','🥉'][index]}{isNew && <span title="New entry">✨</span>}</td>
 				<td class="leaderboard-url">
 					<a href={latest.url}>
 						<img src={`https://v1.indieweb-avatar.11ty.dev/${encodeURIComponent(latest.url)}`} alt={`IndieWeb Avatar for ${displayURL(latest.url)}`} class="leaderboard-list-entry-thumbnail" loading="lazy" decoding="async" width="150" height="150">

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -1,4 +1,4 @@
-interface TestData {
+export interface TestData {
   timestamp: number;
   error?;
   url: string;

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -16,6 +16,7 @@ export interface TestData {
     bestPractices: number;
     seo: number;
     total: number;
+    type?: string;
   };
   firstContentfulPaint: number;
   firstMeaningfulPaint: number;
@@ -48,6 +49,7 @@ export interface TestData {
   axe: {
     passes: number;
     violations: number;
+    error?: boolean;
   };
 };
 

--- a/src/util/formatters.ts
+++ b/src/util/formatters.ts
@@ -1,0 +1,11 @@
+export const showDigits = (num: number, digits = 2) => num.toFixed(digits);
+
+export const displayTime = (num: number) =>
+  num > 850 ? `${showDigits(num / 1000, 2)}s` : `${showDigits(num, 0)}ms`;
+
+export const displayDate = (timestamp: number) =>
+  new Date(timestamp).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: '2-digit',
+  });


### PR DESCRIPTION
This PR adds the tables and graphs showing Lighthouse, Web Vitals, and Page Weight data for each site that are available on the original Speedlify site.