### PR TITLE
Implement GitHub actions to introduce CI/CD and scheduled monthly statistics collection

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,27 @@
+name: Build
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [17.x, 18.x]
+        os: [ubuntu-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pnpm/action-setup@v2.0.1
+      with:
+        version: 7.1.9
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Build
+      run: pnpm build
+    # - name: Unit tests
+    #   run: pnpm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,10 +9,10 @@ jobs:
     - uses: pnpm/action-setup@v2.0.1
       with:
         version: 7.1.9
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16.x
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,11 +4,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [17.x, 18.x]
-        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: pnpm/action-setup@v2.0.1

--- a/.github/workflows/statistics.yml
+++ b/.github/workflows/statistics.yml
@@ -1,0 +1,26 @@
+name: Statistics
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pnpm/action-setup@v2.0.1
+      with:
+        version: 7.1.9
+    - name: Use Node.js 18
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Build
+      run: pnpm build
+    - name: Collect statistics
+      run: pnpm collect-stats
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Generate monthly statistics

--- a/.github/workflows/statistics.yml
+++ b/.github/workflows/statistics.yml
@@ -1,7 +1,7 @@
 name: Statistics
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '0 6 1 * *'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces two features:

- A workflow file to define the build pipeline (with the test step commented out for future implementation).
- A workflow file for monthly statistics collection. This runs on the first day of every month at 6AM (not at, for example, midnight to avoid inevitable daylight savings issues causing the statistics to be recorded on the wrong date)

